### PR TITLE
updated frontend dockerfile

### DIFF
--- a/mern/frontend/Dockerfile
+++ b/mern/frontend/Dockerfile
@@ -11,7 +11,18 @@ WORKDIR /app
 COPY package.json .
 
 # Run the command inside your image filesystem
-RUN npm install
+#It installs all Node.js dependencies listed in package.json.
+
+#It skips all scripts listed under:
+
+#"preinstall"
+
+#"install"
+
+#"postinstall"
+
+RUN npm install --ignore-scripts
+
 
 # Inform Docker that the container is listening on the specified port at runtime
 EXPOSE 5173


### PR DESCRIPTION
-updated frontend dockerfile with:
-RUN npm install --ignore-script

This command installs all your dependencies from package.json, but skips running their lifecycle scripts, like:

"postinstall"

"preinstall"

"install" scripts

Why --ignore-scripts Is Used:
To speed up the build.

To avoid install-time error
-our application is not dependent on cypress so skipping them is not a problem in this application, if at all needed at end you  can add RUN npm rebuild && npm run postinstall


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the installation process to skip running npm lifecycle scripts during dependency installation in the frontend Docker build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->