### PR TITLE
Updated README.md file: changed 'mongodb:latest' to 'mongo:latest'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Open your browser and type `http://localhost:5173`
 
 ### Run the mongodb container
 
-`docker run --network=demo --name mongodb -d -p 27017:27017 -v ~/opt/data:/data/db mongodb:latest`
+`docker run --network=demo --name mongodb -d -p 27017:27017 -v ~/opt/data:/data/db mongo:latest`
 
 ### Build the server
 


### PR DESCRIPTION
Hi @iam-veeramalla ,

This pull request updates the README.md file to correct the Docker command for running the MongoDB container. 

The image name was corrected from mongodb:latest to mongo:latest to reflect the correct Docker image name. This change ensures that users can successfully run the MongoDB container without getting an error regarding the image name.

Before:
docker run --network=demo --name mongodb -d -p 27017:27017 -v ~/opt/data:/data/db mongodb:latest

After:
docker run --network=demo --name mongodb -d -p 27017:27017 -v ~/opt/data:/data/db mongo:latest

Reference Document: https://hub.docker.com/_/mongo/tags

Thanks & Regards,
Nagen & Biswal