### PR TITLE
fix: updated frontend Dockerfile to skip Cypress binary download

### DIFF
--- a/mern/frontend/Dockerfile
+++ b/mern/frontend/Dockerfile
@@ -7,6 +7,7 @@ FROM node:18.9.1
 # Set the working directory
 WORKDIR /app
 
+ENV CYPRESS_INSTALL_BINARY=0
 # Copy the file from your host to your current location
 COPY package.json .
 


### PR DESCRIPTION
This PR fixes issues with the frontend Dockerfile to ensure smooth local development and container builds.

Changes Made

Updated Dockerfile to include ENV CYPRESS_INSTALL_BINARY=0

Prevents unnecessary Cypress binary download during npm install.

Reduces build time and avoids potential build failures inside Docker.

Verified frontend runs correctly on http://localhost:5173 after build.

Cleaned up dependencies (node_modules / package-lock.json) before install for consistency.

✅ Why This Fix Is Important

Original Dockerfile caused build warnings/errors due to Cypress attempting to install a large binary (not required for runtime).

Developers running locally or using Docker images no longer face failed builds.

This keeps the repo more beginner-friendly and reduces onboarding friction.